### PR TITLE
Loader patch

### DIFF
--- a/diffsmhm/loader.py
+++ b/diffsmhm/loader.py
@@ -424,7 +424,7 @@ def load_and_chop_data_bolshoi_planck(
     displ = displ[RANK]
 
     for key in parts.keys():
-        parts[key] = parts[key][displ:displ:rank_count]
+        parts[key] = parts[key][displ:displ+rank_count]
 
     # chop the particle catalog
     parts = mpipartition.distribute(partition, box_length, parts,

--- a/diffsmhm/tests/test_loader.py
+++ b/diffsmhm/tests/test_loader.py
@@ -341,6 +341,11 @@ def test_load_and_chop_data_bolshoi_planck_mmh_known():
         assert "y" in particles.keys()
         assert "z" in particles.keys()
 
+        # check that data is actually present
+        assert len(particles["x"]) > 0
+        assert len(particles["y"]) > 0
+        assert len(particles["z"]) > 0
+
         # to try and combat file not being found when ranks aren't synced perfectly
         COMM.Barrier()
 
@@ -394,6 +399,10 @@ def test_load_and_chop_data_bolshoi_planck_mmh_unknown():
         assert "x" in particles.keys()
         assert "y" in particles.keys()
         assert "z" in particles.keys()
+
+        assert len(particles["x"]) > 0
+        assert len(particles["y"]) > 0
+        assert len(particles["z"]) > 0
 
         # to try and combat file not being found when ranks aren't synced perfectly
         COMM.Barrier()


### PR DESCRIPTION
Typo in indexing caused `load_and_chop_data_bolshoi_planck` to return empty particle list. Fixed this and added some checks in CI to ensure particle list is not empty