### PR TITLE
Check idx to dep

### DIFF
--- a/diffsmhm/galhalo_models/merging.py
+++ b/diffsmhm/galhalo_models/merging.py
@@ -54,6 +54,11 @@ def _jax_deposit_mstar_jax(logsm, indx_to_deposit, frac_to_deposit):
 
 
 def _calculate_indx_to_deposit(upids, halo_ids):
+    # check that each upid exists among the halo IDs
+    n_missing_upid = len(np.setdiff1d(upids[upids != -1], halo_ids))
+    assert n_missing_upid == 0, "_calculate_indx_to_deposit: Missing upids"
+
+    # continue with matching indices
     orig_indices = np.arange(len(halo_ids)).astype("i8")
     indx_to_deposit = np.zeros_like(orig_indices)
 

--- a/diffsmhm/galhalo_models/tests/test_merging.py
+++ b/diffsmhm/galhalo_models/tests/test_merging.py
@@ -79,3 +79,31 @@ def test1():
     #  We set up frac_merge to be positive, so satellites should strictly lose
     #  mass from merging
     assert np.all(np.log10(d["total_mstar"][~cenmask]) < d["logsm"][~cenmask])
+
+
+@pytest.mark.mpi_skip
+def test_calculate_indx_to_deposit_missing():
+    # check that missing throws error
+    upids = np.arange(10, dtype="i")
+    halo_ids = np.arange(9, dtype="i")
+
+    try:
+        ok = False
+        _calculate_indx_to_deposit(upids, halo_ids)
+    except:
+        ok = True
+    finally:
+        assert ok, "calculate_indx_to_deposit failed to identify missing upid"
+
+    # check that all present doesn't throw error
+    upids = np.arange(9, dtype="i")
+
+    try:
+        ok = False
+        _calculate_indx_to_deposit(upids, halo_ids)
+    except:
+        ok = False
+    else:
+        ok = True
+    finally:
+        assert ok, "calculate_indx_to_deposit fails when all upids are present"

--- a/diffsmhm/galhalo_models/tests/test_merging.py
+++ b/diffsmhm/galhalo_models/tests/test_merging.py
@@ -90,7 +90,7 @@ def test_calculate_indx_to_deposit_missing():
     try:
         ok = False
         _calculate_indx_to_deposit(upids, halo_ids)
-    except:
+    except AssertionError:
         ok = True
     finally:
         assert ok, "calculate_indx_to_deposit failed to identify missing upid"
@@ -101,7 +101,7 @@ def test_calculate_indx_to_deposit_missing():
     try:
         ok = False
         _calculate_indx_to_deposit(upids, halo_ids)
-    except:
+    except AssertionError:
         ok = False
     else:
         ok = True


### PR DESCRIPTION
Sometimes if only a very small chunk of a catalog is loaded, not every halo present in 'upid' is also in 'halo_id'. This is an issue for calculating merging, so we add a check 